### PR TITLE
Changed imageio, ffmpeg install command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3
 RUN pip install imageio
 # install ffmpeg from imageio.
-RUN python -c "import imageio; imageio.plugins.ffmpeg.download()"
+RUN pip install imageio-ffmpeg
 
 FROM bethgelab/deeplearning:cuda9.0-cudnn7
 RUN apt-get update


### PR DESCRIPTION
When I tried to build the docker container this command was listed as deprecated and suggested using the command I inserted. It seemed to build properly afterward. I'm still working on the de-novo start of the container so I can't guarantee it built correctly.